### PR TITLE
Fix durable name cannot contain `.` error

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
@@ -46,7 +46,7 @@ export function serverConsumerOptionsBuilder(
   deliverTo && opts.deliverTo(createInbox(deliverTo));
 
   description && opts.description(description);
-  durable && opts.durable(`${durable}-${subject.replace(".", "_").replace("*", "_ALL")}`)
+  durable && opts.durable(`${durable}-${subject.replaceAll(".", "_").replaceAll("*", "_ALL")}`)
   filterSubject && opts.filterSubject(filterSubject);
   flowControl && opts.flowControl();
   headersOnly && opts.headersOnly();


### PR DESCRIPTION
If subject has more than one dot (eg. `time.us.east.atlanta`) will cause durable name canoot contains `.` error.
use String.replaceAll will actually replace all `.` to `_`.