### PR TITLE
Connected hook

### DIFF
--- a/packages/nats-listener/package-lock.json
+++ b/packages/nats-listener/package-lock.json
@@ -6,10 +6,9 @@
 	"packages": {
 		"": {
 			"name": "nats-listener",
-			"version": "0.1.1",
+			"version": "0.1.2-pre.0",
 			"license": "UNLICENSED",
 			"dependencies": {
-				"@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.2.0",
 				"@nestjs/common": "^8.0.0",
 				"@nestjs/core": "^8.0.0",
 				"@nestjs/microservices": "^8.2.3",
@@ -1286,17 +1285,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"node_modules/@nestjs-plugins/nestjs-nats-jetstream-transport": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nestjs-plugins/nestjs-nats-jetstream-transport/-/nestjs-nats-jetstream-transport-1.2.0.tgz",
-			"integrity": "sha512-TVdkZZvZqWLldOH4Lmd7I7tBP4GEIp/CxX0o8dH4aPOSmBuIG65bRQHQ+h1oHnA5PdS17AAYml26kZMkHpURaQ==",
-			"dependencies": {
-				"@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.1.8",
-				"nats": "^2.6.1",
-				"reflect-metadata": "^0.1.13",
-				"rxjs": "^7.4.0"
 			}
 		},
 		"node_modules/@nestjs/cli": {
@@ -9908,17 +9896,6 @@
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
-		"@nestjs-plugins/nestjs-nats-jetstream-transport": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@nestjs-plugins/nestjs-nats-jetstream-transport/-/nestjs-nats-jetstream-transport-1.2.0.tgz",
-			"integrity": "sha512-TVdkZZvZqWLldOH4Lmd7I7tBP4GEIp/CxX0o8dH4aPOSmBuIG65bRQHQ+h1oHnA5PdS17AAYml26kZMkHpURaQ==",
-			"requires": {
-				"@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.1.8",
-				"nats": "^2.6.1",
-				"reflect-metadata": "^0.1.13",
-				"rxjs": "^7.4.0"
 			}
 		},
 		"@nestjs/cli": {

--- a/packages/nats-listener/src/main.ts
+++ b/packages/nats-listener/src/main.ts
@@ -16,9 +16,7 @@ async function bootstrap() {
         connectedHook: async (nc) => {
           logger.log('connected');
           for await (const s of nc.status()) {
-            if (s.type == Events.Reconnect) {
-              console.log(s.data);
-            }
+            console.log(s)
           }
         },
       },

--- a/packages/nats-listener/src/main.ts
+++ b/packages/nats-listener/src/main.ts
@@ -5,7 +5,7 @@ import { AppModule } from './app.module';
 import { CustomStrategy } from '@nestjs/microservices';
 import { NatsJetStreamServer } from '@nestjs-plugins/nestjs-nats-jetstream-transport';
 import { Logger } from '@nestjs/common';
-import { Events } from 'nats';
+import { DebugEvents, Events } from 'nats';
 
 async function bootstrap() {
   const logger = new Logger();
@@ -14,9 +14,11 @@ async function bootstrap() {
       connectionOptions: {
         name: 'myservice-listener',
         connectedHook: async (nc) => {
-          logger.log('connected');
+          logger.log('Connected to ' + nc.getServer());
           for await (const s of nc.status()) {
-            console.log(s)
+            if (s.type == DebugEvents.PingTimer) {
+              console.log('We got ping timer attempt: ' + s.data);
+            }
           }
         },
       },

--- a/packages/nats-listener/src/main.ts
+++ b/packages/nats-listener/src/main.ts
@@ -4,12 +4,23 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { CustomStrategy } from '@nestjs/microservices';
 import { NatsJetStreamServer } from '@nestjs-plugins/nestjs-nats-jetstream-transport';
+import { Logger } from '@nestjs/common';
+import { Events } from 'nats';
 
 async function bootstrap() {
+  const logger = new Logger();
   const options: CustomStrategy = {
     strategy: new NatsJetStreamServer({
       connectionOptions: {
         name: 'myservice-listener',
+        connectedHook: async (nc) => {
+          logger.log('connected');
+          for await (const s of nc.status()) {
+            if (s.type == Events.Reconnect) {
+              console.log(s.data);
+            }
+          }
+        },
       },
       consumerOptions: {
         deliverGroup: 'myservice-group',

--- a/packages/nats-publisher/package-lock.json
+++ b/packages/nats-publisher/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "nats-publisher",
-			"version": "0.2.0-alpha.0",
+			"version": "0.2.0-pre.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@nestjs/common": "^8.0.0",

--- a/packages/nats-publisher/src/app.module.ts
+++ b/packages/nats-publisher/src/app.module.ts
@@ -1,13 +1,17 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { NatsJetStreamTransport, NatsJetStreamClient } from '@nestjs-plugins/nestjs-nats-jetstream-transport';
+import {
+  NatsJetStreamTransport,
+  NatsJetStreamClient,
+} from '@nestjs-plugins/nestjs-nats-jetstream-transport';
 
 @Module({
   imports: [
     NatsJetStreamTransport.register({
       connectionOptions: {
         name: 'myservice-publisher',
+        connectedHook: (nc) => console.log('publisher connect', nc),
       },
     }),
   ],

--- a/packages/nats-publisher/src/app.module.ts
+++ b/packages/nats-publisher/src/app.module.ts
@@ -11,7 +11,7 @@ import {
     NatsJetStreamTransport.register({
       connectionOptions: {
         name: 'myservice-publisher',
-        connectedHook: (nc) => console.log('publisher connect', nc),
+        connectedHook: (nc) => console.log('From hook: publisher connected to ', nc.getServer()),
       },
     }),
   ],

--- a/packages/nats-publisher/src/app.service.ts
+++ b/packages/nats-publisher/src/app.service.ts
@@ -1,6 +1,7 @@
 import { NatsJetStreamClientProxy, NatsJetStreamClient } from '@nestjs-plugins/nestjs-nats-jetstream-transport';
 import { Injectable } from '@nestjs/common';
-import { PubAck } from 'nats';
+import { Events, PubAck } from 'nats';
+import { async } from 'rxjs';
 
 interface OrderCreatedEvent {
   id: number;
@@ -23,7 +24,13 @@ const ORDER_DELETED = 'order.deleted';
 
 @Injectable()
 export class AppService {
-  constructor(private client: NatsJetStreamClient) {}
+  constructor(private client: NatsJetStreamClient) {
+    client.connect().then(async nc => {
+      for await (const s of nc.status()) {
+        console.log(s);
+      }
+    })     
+  }
 
   createOrder(): string {
     this.client

--- a/packages/nestjs-nats-jetstream-transport/package-lock.json
+++ b/packages/nestjs-nats-jetstream-transport/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@nestjs-plugins/nestjs-nats-jetstream-transport",
-			"version": "1.3.0-dev.0",
+			"version": "1.3.2",
 			"license": "ISC",
 			"dependencies": {
 				"nats": "^2.6.1",

--- a/packages/nestjs-nats-jetstream-transport/src/client.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/client.ts
@@ -19,6 +19,7 @@ export class NatsJetStreamClientProxy extends ClientProxy {
   async connect(): Promise<NatsConnection> {
     if (!this.nc) {
       this.nc = await connect(this.options.connectionOptions);
+      this.options.connectionOptions.connectedHook(this.nc);
     }
 
     return this.nc;

--- a/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-connection-options.interface.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-connection-options.interface.ts
@@ -1,5 +1,6 @@
-import { ConnectionOptions } from "nats";
+import { ConnectionOptions, NatsConnection } from "nats";
 
 export interface NatsConnectionOptions extends ConnectionOptions {
   name: string;
+  connectedHook?: (nc: NatsConnection) => void;
 }

--- a/packages/nestjs-nats-jetstream-transport/src/server.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/server.ts
@@ -30,6 +30,7 @@ export class NatsJetStreamServer
   async listen(callback: () => null) {
     if (!this.nc) {
       this.nc = await connect(this.options.connectionOptions);
+      this.options.connectionOptions.connectedHook(this.nc);
     }
     this.jsm = await this.nc.jetstreamManager(this.options.jetStreamOptions);
     if (this.options.streamConfig) {


### PR DESCRIPTION
Access the underlaying nats connection object through a connected hook.

Example code:
```javascript
const logger = new Logger();
  const options: CustomStrategy = {
    strategy: new NatsJetStreamServer({
      connectionOptions: {
        name: 'myservice-listener',
        connectedHook: async (nc) => {
          logger.log('Connected to ' + nc.getServer());
          for await (const s of nc.status()) {
            if (s.type == DebugEvents.PingTimer) {
              console.log('We got ping timer attempt: ' + s.data);
            }
          }
        },
      },
```