### PR TITLE
fix: Replace project relative path

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
@@ -1,5 +1,5 @@
 import { consumerOpts, createInbox } from 'nats';
-import { ServerConsumerOptions } from 'src/interfaces/server-consumer-options.interface';
+import { ServerConsumerOptions } from '../interfaces/server-consumer-options.interface';
 
 export function serverConsumerOptionsBuilder(
   serverConsumerOptions: ServerConsumerOptions,


### PR DESCRIPTION
I don't know how the project works for others, but for me path relative to project caused error thus I was unable to start the app at all:

Cannot find module 'src/interfaces/server-consumer-options.interface' or its corresponding type declarations.