### PR TITLE
feat: :sparkles: Modify nestjs-nats-jetstream-transport to join subjects instead of override them.

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/server.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/server.ts
@@ -120,9 +120,12 @@ export class NatsJetStreamServer
     );
 
     if (stream) {
+      const streamSubjects = new Set([...stream.config.subjects, ...streamConfig.subjects]);
+
       const streamInfo = await this.jsm.streams.update(stream.config.name, {
         ...stream.config,
         ...streamConfig,
+        subjects: [...streamSubjects.keys()],
       });
       this.logger.log(`Stream ${streamInfo.config.name} updated`);
     } else {


### PR DESCRIPTION
# Description
This issue modifies the `nats-jestream-transport` to join subjects created in different files instead of override them.

# Motivation and Context
When using microservices for example, it isn't posible to create the subjects to the same stream in different places. That's because the last microservice to run will override the subjects created previously.

# How Has This Been Tested (just an example)?
- In different microservices, create subjects to the same stream.
- Run the project.
- After succesfully running the project, the stream must have the subjects created in both files.

# Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)