### PR TITLE
Add NatsJetStreamClient to Transport providers

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/nats-jetstream-transport.module.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/nats-jetstream-transport.module.ts
@@ -13,6 +13,7 @@ export class NatsJetStreamTransport {
         useValue: options,
       },
       NatsJetStreamClientProxy,
+      NatsJetStreamClient,
     ];
 
     return {


### PR DESCRIPTION
NatsJetStreamClient wasn't being exported from the sync register method.  Adding it.