### PR TITLE
Support the second wildcard (>) in durable consumers

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/utils/server-consumer-options-builder.ts
@@ -50,7 +50,7 @@ export function serverConsumerOptionsBuilder(
   description && opts.description(description);
   durable &&
     opts.durable(
-      `${durable}-${subject.replaceAll('.', '_').replaceAll('*', '_ALL')}`,
+      `${durable}-${subject.replaceAll('.', '_').replaceAll('*', '_ALL').replaceAll('>', '_ALL')}`,
     );
   filterSubject && opts.filterSubject(filterSubject);
   flowControl && opts.flowControl();


### PR DESCRIPTION
NATS subject patterns support the ">" character at the end to match with any number of extra tokens after that point (whereas * is single-token): https://docs.nats.io/nats-concepts/subjects#matching-multiple-tokens

So this is just a tiny fix so that use of > in an event pattern doesn't try to use that character in a durable consumer name, where it is a restricted character.