### PR TITLE
Feature: Allow multiple stream config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15094,7 +15094,7 @@
       "version": "0.1.12",
       "license": "UNLICENSED",
       "dependencies": {
-        "@nestjs-plugins/nestjs-nats-jetstream-transport": "^2.0.0",
+        "@nestjs-plugins/nestjs-nats-jetstream-transport": "file:../nestjs-nats-jetstream-transport",
         "@nestjs/common": "^8.0.0",
         "@nestjs/core": "^8.0.0",
         "@nestjs/microservices": "^8.2.3",
@@ -15437,7 +15437,6 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.3.15",
         "nats": "^2.6.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.4.0"
@@ -15452,17 +15451,6 @@
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
         "typescript": "^4.4.4"
-      }
-    },
-    "packages/nestjs-nats-jetstream-transport/node_modules/@nestjs-plugins/nestjs-nats-jetstream-transport": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@nestjs-plugins/nestjs-nats-jetstream-transport/-/nestjs-nats-jetstream-transport-1.4.4.tgz",
-      "integrity": "sha512-5/FIX6TOxK2TDikWTXpkxZXCn75IQdvoQ6LnUlp1YPZ8yFKToJ/6I8q+4IrWRcIWgrG13rT0Gjf0r6wSVi+pVg==",
-      "dependencies": {
-        "@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.3.15",
-        "nats": "^2.6.1",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.4.0"
       }
     },
     "packages/nestjs-nats-jetstream-transport/node_modules/brace-expansion": {

--- a/packages/nats-listener/.eslintrc.js
+++ b/packages/nats-listener/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parserOptions: {
     project: 'tsconfig.json',
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [

--- a/packages/nats-listener/package.json
+++ b/packages/nats-listener/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs-plugins/nestjs-nats-jetstream-transport": "^2.0.0",
+    "@nestjs-plugins/nestjs-nats-jetstream-transport": "file:../nestjs-nats-jetstream-transport",
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "@nestjs/microservices": "^8.2.3",

--- a/packages/nats-listener/src/app.controller.ts
+++ b/packages/nats-listener/src/app.controller.ts
@@ -68,6 +68,36 @@ export class AppController {
     console.log('received: ' + context.message.subject, data);
   }
 
+  /** Added more listeners for the other subject */
+  @EventPattern('other.updated')
+  public async otherUpdatedHandler(
+    @Payload() data: string,
+    @Ctx() context: NatsJetStreamContext,
+  ) {
+    context.message.ack();
+    console.log('received: ' + context.message.subject, data);
+  }
+
+  @EventPattern('other.created')
+  public async otherCreatedHandler(
+    @Payload() data: { id: number; name: string },
+    @Ctx() context: NatsJetStreamContext,
+  ) {
+    console.log(context.message.headers);
+    console.log(context.message.info);
+    context.message.ack();
+    console.log('received: ' + context.message.subject, data);
+  }
+
+  @EventPattern('other.deleted')
+  public async otherDeletedHandler(
+    @Payload() data: any,
+    @Ctx() context: NatsJetStreamContext,
+  ) {
+    context.message.ack();
+    console.log('received: ' + context.message.subject, data);
+  }
+
   // request - response
   @MessagePattern({ cmd: 'sum' })
   async accumulate(

--- a/packages/nats-listener/src/main.ts
+++ b/packages/nats-listener/src/main.ts
@@ -11,10 +11,16 @@ import { Logger } from '@nestjs/common';
 import { DebugEvents, Events } from 'nats';
 
 async function bootstrap() {
-  const streamConfig: NatsStreamConfig = {
-    name: 'mystream',
-    subjects: ['order.*'],
-  };
+  const streamConfig: NatsStreamConfig[] = [
+    {
+      name: 'mystream',
+      subjects: ['order.*'],
+    },
+    {
+      name: 'my-other-stream',
+      subjects: ['other.*'],
+    },
+  ];
   const logger = new Logger();
   const options: CustomStrategy = {
     strategy: new NatsJetStreamServer({

--- a/packages/nats-publisher/.eslintrc.js
+++ b/packages/nats-publisher/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
   parserOptions: {
     project: 'tsconfig.json',
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [

--- a/packages/nestjs-nats-jetstream-transport/.eslintrc.js
+++ b/packages/nestjs-nats-jetstream-transport/.eslintrc.js
@@ -1,24 +1,25 @@
 module.exports = {
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: "tsconfig.json",
-    sourceType: "module",
+    project: 'tsconfig.json',
+    sourceType: 'module',
+    tsconfigRootDir: __dirname,
   },
-  plugins: ["@typescript-eslint/eslint-plugin"],
+  plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
-    "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended",
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
   ],
   root: true,
   env: {
     node: true,
     jest: true,
   },
-  ignorePatterns: [".eslintrc.js"],
+  ignorePatterns: ['.eslintrc.js'],
   rules: {
-    "@typescript-eslint/interface-name-prefix": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 };

--- a/packages/nestjs-nats-jetstream-transport/README.md
+++ b/packages/nestjs-nats-jetstream-transport/README.md
@@ -347,6 +347,13 @@ async function bootstrap() {
         name: 'mystream',
         subjects: ['order.*'],
       },
+      //   streamConfig: [{
+      //     name: 'mystream',
+      //     subjects: ['order.*'],
+      //   },{
+      //     name: 'myOtherStream',
+      //     subjects: ['other.*'],
+      //   }],
     }),
   };
 

--- a/packages/nestjs-nats-jetstream-transport/package.json
+++ b/packages/nestjs-nats-jetstream-transport/package.json
@@ -32,7 +32,6 @@
   "author": "Bernt Anker [bernt.anker@gmail.com]",
   "license": "ISC",
   "dependencies": {
-    "@nestjs-plugins/nestjs-nats-jetstream-transport": "^1.3.15",
     "nats": "^2.6.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.4.0"

--- a/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-jetstream-server-options.interface.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-jetstream-server-options.interface.ts
@@ -8,5 +8,5 @@ export interface NatsJetStreamServerOptions {
     Pick<NatsConnectionOptions, 'name'>;
   consumerOptions: Partial<ServerConsumerOptions>;
   jetStreamOptions?: JetStreamOptions;
-  streamConfig?: NatsStreamConfig;
+  streamConfig?: NatsStreamConfig | NatsStreamConfig[];
 }


### PR DESCRIPTION
This PR allows for a single or array of streamConfig. For example
```js

// Single stream config
streamConfig: {
        name: 'mystream',
        subjects: ['order.*'],
},

// multi stream config
 streamConfig: [{
      name: 'mystream',
      subjects: ['order.*'],
  },{
      name: 'myOtherStream',
      subjects: ['other.*'],
}],
```

Output 

<img width="1202" alt="Screenshot 2023-11-23 at 22 03 48" src="https://github.com/Redningsselskapet/nestjs-plugins/assets/311705/e8c77c5d-39a5-4827-ba3a-d5585eaeb650">