### PR TITLE
Add Parameter to Configure Custom Codec

### DIFF
--- a/packages/nestjs-nats-jetstream-transport/src/client.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/client.ts
@@ -17,13 +17,19 @@ import { NatsRequestRecord } from './utils/nats-request-record-builder';
 @Injectable()
 export class NatsJetStreamClientProxy extends ClientProxy {
   private nc: NatsConnection;
-  private codec: Codec<JSON>;
+  private codec: Codec<unknown>;
 
   constructor(
     @Inject(NATS_JETSTREAM_OPTIONS) private options: NatsJetStreamClientOptions,
   ) {
     super();
-    this.codec = JSONCodec();
+
+    // Use provided codec if exists, otherwise use JSONCodec as default
+    if (options.connectionOptions.codec) {
+      this.codec = options.connectionOptions.codec;
+    } else {
+      this.codec = JSONCodec();
+    }
   }
 
   async connect(): Promise<NatsConnection> {

--- a/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-connection-options.interface.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/interfaces/nats-connection-options.interface.ts
@@ -1,6 +1,7 @@
-import { ConnectionOptions, NatsConnection } from 'nats';
+import { Codec, ConnectionOptions, NatsConnection } from 'nats';
 
 export interface NatsConnectionOptions extends ConnectionOptions {
   name: string;
+  codec?: Codec<unknown>;
   connectedHook?: (nc: NatsConnection) => void;
 }

--- a/packages/nestjs-nats-jetstream-transport/src/server.ts
+++ b/packages/nestjs-nats-jetstream-transport/src/server.ts
@@ -20,12 +20,18 @@ export class NatsJetStreamServer
 {
   readonly transportId: symbol = NATS_JETSTREAM_TRANSPORT;
   private nc: NatsConnection;
-  private codec: Codec<JSON>;
+  private codec: Codec<unknown>;
   private jsm: JetStreamManager;
 
   constructor(private options: NatsJetStreamServerOptions) {
     super();
-    this.codec = JSONCodec();
+
+    // Use provided codec if exists, otherwise use JSONCodec as default
+    if (options.connectionOptions.codec) {
+      this.codec = options.connectionOptions.codec;
+    } else {
+      this.codec = JSONCodec();
+    }
   }
 
   async listen(callback: () => void) {


### PR DESCRIPTION
Add configuration option to use custom codec by implementing NATS codec interface.

Example usage:
```TypeScript
// ...other imports omitted

// Custom codec (in this case CBOR based)
import CBOR from "cbor";
import { Codec } from "nats";

class CborCodec implements Codec<unknown> {
  encode(d: unknown): Uint8Array {
    return CBOR.encodeOne(d, { highWaterMark: 1049000 });
  }

  decode(a: Uint8Array): unknown {
    return CBOR.decodeFirstSync(a, { highWaterMark: 1049000 }) as unknown;
  }
}

// Module declaration
@Global()
@Module({
  imports: [
    NatsJetStreamTransport.registerAsync({
      inject: [ConfigService],
      useFactory: (configService: ConfigService) => {
        return {
          connectionOptions: {
            servers: "nats://broker.example.com:4222",
            codec: new CborCodec(),
          },
        };
      },
    }),
  ],
  providers: [NatsService],
  exports: [NatsService],
})
export class NatsGlobalModule {}
```